### PR TITLE
docs: typo fix Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker-compose --env-file .bitcoin.env -f mutiny.docker-compose.yml up -d
 
 ## (Optional) Download a snapshot of the Reth and Comet database
 ## For instructions see below "Setup Testnet With CAAS".
-## This step is optional but will greatly reduce the syncing times as one only needs to sync the blocks of since midnight.
+## This step is optional but will greatly reduce the syncing times as one only needs to sync the blocks since midnight.
 
 ## Start the services
 make start-testnet-rpc


### PR DESCRIPTION
### Description
While going through the documentation, I noticed a typo in the **Getting Started** section. The phrase:  
> "...one only needs to sync the blocks of since midnight."  

contained an unnecessary "of." I've corrected it to:  
> "...one only needs to sync the blocks since midnight."  

This minor fix improves the readability of the instructions without altering their intent.